### PR TITLE
fix: auto scroll to page top on navigation

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -12,6 +12,7 @@ import { FooterWrapper } from "../components/footer-wrapper";
 import { NowPlayingWidget } from "../components/now-playing-widget";
 import { ObservabilityProvider } from "../components/observability-provider";
 import { PreviewNotification } from "../components/preview-notification";
+import { ScrollToTop } from "../components/scroll-to-top";
 import { WebVitalsReporter } from "../components/web-vitals-reporter";
 import {
   getFooterConfig,
@@ -64,6 +65,7 @@ export default async function RootLayout({ children }: PropsWithChildren) {
         <ConsentProvider />
         <ObservabilityProvider />
         <WebVitalsReporter />
+        <ScrollToTop />
         <LazyMotionProvider>
           <StoryblokProvider>
             {/* Global UI Elements (not affected by page containers) */}

--- a/apps/web/components/scroll-to-top.tsx
+++ b/apps/web/components/scroll-to-top.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+
+/**
+ * ScrollToTop component
+ * Automatically scrolls to top on route change
+ */
+export function ScrollToTop() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: "instant" });
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
This pull request adds a new global component to the web app that ensures the page scrolls to the top whenever the route changes. This improves user experience by preventing unexpected scroll positions when navigating between pages.

User experience improvements:

* Added a new `ScrollToTop` component in `apps/web/components/scroll-to-top.tsx` that listens for route changes and scrolls the window to the top automatically.
* Integrated the `ScrollToTop` component into the global layout in `apps/web/app/layout.tsx` so it is active for all pages. [[1]](diffhunk://#diff-c235c52626fe2cfbb53241bb015bdd7b5f5a28f9a10a08e1f401238e773fa7adR15) [[2]](diffhunk://#diff-c235c52626fe2cfbb53241bb015bdd7b5f5a28f9a10a08e1f401238e773fa7adR68)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic scroll-to-top behavior when navigating between pages to improve user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->