### PR TITLE
[wip] fix: arcjet integration

### DIFF
--- a/apps/web/app/api/revalidate/route.ts
+++ b/apps/web/app/api/revalidate/route.ts
@@ -1,3 +1,4 @@
+import { applyArcjetProtection } from "@httpjpg/security";
 import { CACHE_TAGS } from "@httpjpg/storyblok-api";
 import { revalidatePath, revalidateTag } from "next/cache";
 import { type NextRequest, NextResponse } from "next/server";
@@ -26,6 +27,10 @@ interface StoryblokWebhookPayload {
  * webhook-secret: YOUR_REVALIDATE_SECRET
  */
 export async function POST(request: NextRequest) {
+  // Apply Arcjet protection for webhooks
+  const protection = await applyArcjetProtection(request, "webhook");
+  if (protection) return protection;
+
   try {
     // Verify secret from header or query param
     const headerSecret = request.headers.get("webhook-secret");

--- a/apps/web/app/api/spotify/now-playing/route.ts
+++ b/apps/web/app/api/spotify/now-playing/route.ts
@@ -13,12 +13,17 @@
 
 import { env } from "@httpjpg/env";
 import { getAccessToken, getCurrentlyPlaying } from "@httpjpg/now-playing";
-import { NextResponse } from "next/server";
+import { applyArcjetProtection } from "@httpjpg/security";
+import { type NextRequest, NextResponse } from "next/server";
 
 export const runtime = "edge";
 export const revalidate = 0; // Don't cache
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  // Apply Arcjet protection
+  const protection = await applyArcjetProtection(request, "api");
+  if (protection) return protection;
+
   try {
     // Get fresh access token
     const accessToken = await getAccessToken(

--- a/packages/security/src/index.ts
+++ b/packages/security/src/index.ts
@@ -1,2 +1,3 @@
 export { aj, ajApi, ajWebhook } from "./arcjet";
 export { withArcjet } from "./middleware";
+export { applyArcjetProtection } from "./protection";

--- a/packages/security/src/middleware.ts
+++ b/packages/security/src/middleware.ts
@@ -1,12 +1,13 @@
-import type { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
 import { aj } from "./arcjet";
 
 /**
  * Arcjet middleware for Next.js
  * Protects all routes with shield, bot detection, and rate limiting
  */
-export async function withArcjet(request: NextRequest) {
+export async function withArcjet(request: any) {
+  // Dynamically import NextResponse to use the caller's Next.js version
+  const { NextResponse } = await import("next/server");
+
   const decision = await aj.protect(request);
 
   if (decision.isDenied()) {

--- a/packages/security/src/protection.ts
+++ b/packages/security/src/protection.ts
@@ -1,6 +1,4 @@
-import { aj, ajApi, ajWebhook } from "@httpjpg/security";
-import type { NextRequest } from "next/server";
-import { NextResponse } from "next/server";
+import { aj, ajApi, ajWebhook } from "./arcjet";
 
 /**
  * Apply Arcjet protection to API routes and webhooks
@@ -20,9 +18,12 @@ import { NextResponse } from "next/server";
  * ```
  */
 export async function applyArcjetProtection(
-  request: NextRequest,
+  request: any, // Use any to avoid Next.js version conflicts
   type: "default" | "api" | "webhook" = "default",
-): Promise<NextResponse | null> {
+): Promise<any> {
+  // Dynamically import NextResponse to use the caller's Next.js version
+  const { NextResponse } = await import("next/server");
+
   // Select appropriate Arcjet instance
   let arcjetInstance = aj;
 


### PR DESCRIPTION
This pull request introduces Arcjet security protection across multiple API routes and middleware in the web application, centralizes Arcjet logic into the shared `@httpjpg/security` package, and updates the codebase to dynamically import Next.js response objects for compatibility. The main focus is to enhance security (rate limiting, bot detection, and shielding) for API and webhook endpoints while keeping middleware lightweight and maintainable.

**Security Enhancements and Integration:**

* Added Arcjet protection to API routes (`/api/spotify/now-playing` and `/api/revalidate`) by using the new `applyArcjetProtection` utility, which applies rate limiting and bot detection before processing requests. [[1]](diffhunk://#diff-71e93baf00a7c607d3f5cea4a0d7fd29fc611815b12c75db9edbdfa6875c664aL16-R26) [[2]](diffhunk://#diff-15be136df20d9a6b7585e53f44059311dcdf8cf565d6024838753c6717ccf130R1) [[3]](diffhunk://#diff-15be136df20d9a6b7585e53f44059311dcdf8cf565d6024838753c6717ccf130R30-R33)
* Updated `middleware.ts` to apply Arcjet protection to all requests except for Storyblok Visual Editor integration, providing early response for denied requests (rate-limited, bots, or forbidden). [[1]](diffhunk://#diff-63df75659fc4d32b8f4a402f90ded1b436199e5a75c705619496af33c7aa02c7R1) [[2]](diffhunk://#diff-63df75659fc4d32b8f4a402f90ded1b436199e5a75c705619496af33c7aa02c7L58-R62) [[3]](diffhunk://#diff-63df75659fc4d32b8f4a402f90ded1b436199e5a75c705619496af33c7aa02c7R72-R91)

**Codebase Refactoring and Centralization:**

* Moved and renamed `arcjet-protection.ts` from `apps/web/lib` to `packages/security/src/protection.ts`, consolidating Arcjet logic in the shared package. [[1]](diffhunk://#diff-d4a17ff8998e99f3174c66f71ea52e5fc6f1b1263e2a032a22f20e35942c6499L1-R1) [[2]](diffhunk://#diff-d4a17ff8998e99f3174c66f71ea52e5fc6f1b1263e2a032a22f20e35942c6499L23-R26)
* Exported `applyArcjetProtection` from `@httpjpg/security` to standardize its usage across the codebase.

**Compatibility Improvements:**

* Updated Arcjet-related utilities (`withArcjet`, `applyArcjetProtection`) to dynamically import `NextResponse` at runtime, ensuring compatibility with different Next.js versions and reducing bundle size. [[1]](diffhunk://#diff-eb58303cd35abe664b6287504eeb8130206edbefa91327500cc786923e5eca0eL1-R10) [[2]](diffhunk://#diff-d4a17ff8998e99f3174c66f71ea52e5fc6f1b1263e2a032a22f20e35942c6499L23-R26)

These changes collectively improve the security posture of the application, simplify Arcjet integration, and make the codebase more maintainable and future-proof.